### PR TITLE
Inserting fonts colors and cloudinary fix 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,12 +32,13 @@ gem 'bootsnap', '>= 1.4.2', require: false
 gem 'autoprefixer-rails'
 gem 'font-awesome-sass'
 gem 'simple_form'
+gem 'cloudinary', '~> 1.16.0'
 
 group :development, :test do
   gem 'pry-byebug'
   gem 'pry-rails'
   gem 'dotenv-rails'
-  gem 'cloudinary', '~> 1.16.0'
+
 
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/app/assets/stylesheets/config/_bootstrap_variables.scss
+++ b/app/assets/stylesheets/config/_bootstrap_variables.scss
@@ -12,7 +12,7 @@ $font-size-base: 1rem;
 // Colors
 $body-color: $gray;
 $primary:    $blue;
-$success:    $green;
+$success:    $button-green;
 $info:       $yellow;
 $danger:     $red;
 $warning:    $orange;

--- a/app/assets/stylesheets/config/_colors.scss
+++ b/app/assets/stylesheets/config/_colors.scss
@@ -5,6 +5,7 @@ $red: #FD1015;
 $blue: #167FFB;
 $yellow: #FFC65A;
 $orange: #E67E22;
-$green: #1EDD88;
 $gray: #0E0000;
 $light-gray: #F4F4F4;
+$home-green: #255641;
+$button-green: #256338;

--- a/app/assets/stylesheets/config/_fonts.scss
+++ b/app/assets/stylesheets/config/_fonts.scss
@@ -1,9 +1,9 @@
 // Import Google fonts
-@import url('https://fonts.googleapis.com/css?family=Nunito:400,700|Work+Sans:400,700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Poppins:wght@200;300;400;500&display=swap');
 
 // Define fonts for body and headers
-$body-font: "Work Sans", "Helvetica", "sans-serif";
-$headers-font: "Nunito", "Helvetica", "sans-serif";
+$body-font: "Poppins", "sans-serif";
+$headers-font: "Poppins", "sans-serif";
 
 // To use a font file (.woff) uncomment following lines
 // @font-face {

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -36,7 +36,7 @@ Rails.application.configure do
   # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for NGINX
 
   # Store uploaded files on the local file system (see config/storage.yml for options).
-  config.active_storage.service = :local
+  config.active_storage.service = :cloudinary
 
   # Mount Action Cable outside main process or domain.
   # config.action_cable.mount_path = nil


### PR DESCRIPTION
**fonts.scss:**
imported font "Poppins" from google.fonts (imported 200, 300, 400, 500); 
changed font from default (nunito and work-sans) to Poppins; 

**colors.scss**
added two green colors: $home-green (to be used on homepage) and $button-green (to be used on buttons in pages)

cloudinary fix: 
- in Gemfile moved gem 'cloudinary', '~> 1.16.0' because it was only in development 